### PR TITLE
Alternative translations fix: TypeError: 'NoneType' object is not subscriptable

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -334,6 +334,8 @@ class GoogleTranslate(QDialog):
                                 alt_translations += '<tr><td>{}</td><td style="color: #5f6368; font-size: 19px;">{}</td><td>{}</td></tr>'.format(t[0], ', '.join(t[2]), freq)
                             alt_translations += '</tbody>'
                         alt_translations = '<table>' + alt_translations + '</table>'
+                    except TypeError:
+                        pass
                     except IndexError:
                         pass
 


### PR DESCRIPTION
@kelciour thank you for Alternative translations feature, it is awesome and very useful!

This PR fixes following error:

```
Error:

Traceback (most recent call last):
  File "__init__.py", line 320, in accept
    for d in data[3][5][0]:
TypeError: 'NoneType' object is not subscriptable
```

This error is appears for words that does not have alternative translations for example: https://translate.google.com/?sl=en&tl=lt&text=concatenated&op=translate