### PR TITLE
Fix for Qt6 compatibility

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -191,7 +191,7 @@ class GoogleTranslate(QDialog):
 
         self.config = mw.addonManager.getConfig(__name__)
 
-        self.setContextMenuPolicy(Qt.CustomContextMenu)
+        self.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self.customContextMenuRequested.connect(self.on_context_menu)
 
         self.form.sourceField.currentIndexChanged.connect(onSourceFieldChanged)


### PR DESCRIPTION
The Qt5 compatibility layer is disabled by default in Anki 23.10
