### PR TITLE
Adding tags/topics for definitions

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -74,6 +74,25 @@ def parse_translated_data(data):
             definitions.append('<ol>')
             for m in d[1]:
                 defn = m[0]
+
+                try:
+                    word_topics = []
+                    style = "border: 1px slategray solid; color: slategray; padding: 0 4px; margin: 0 4px;"
+
+                    for tags_array in m[3]:
+                        if tags_array is not None:
+                            for tag in tags_array:
+                                if tag and tag.strip():
+                                    word_topics.append(tag)
+
+                    if len(word_topics) > 0:
+                        result = ''
+                        for topic in word_topics:
+                            result += f'<div class="PG9puc" style="{style}">{topic}</div>'
+                        defn = f'<div class="CF8Iy CLHVBf" style="display: inline-flex">{result}</div>' + defn
+                except IndexError:
+                    pass
+
                 try:
                     ex = m[2] or ""
                     if ex:


### PR DESCRIPTION
### Explanation

Hi. I've been using this patch for some time now to show tags/topics (_informal_, _literary_, _archaic_, etc) of definitions.

It would be awesome if this could be part of the plugin. Thanks.

### **_Before:_**
![anki_PtPUHZ3cRb](https://github.com/kelciour/google-translate/assets/109849242/3ea959c4-0174-405a-bfc3-fa02711c2d38)

### **_After:_**
![anki_fSaHUIYwbn](https://github.com/kelciour/google-translate/assets/109849242/e62b1866-045d-443c-aba2-4ad8e3ec6dab)

### **_Looks fine with black and light themes:_**
![anki_iU93lpSigy](https://github.com/kelciour/google-translate/assets/109849242/111ec49f-497e-4ffc-9b8a-f81e143b2ac4)
